### PR TITLE
make missed error be handled

### DIFF
--- a/pkg/gpu/nvidia/gpumanager.go
+++ b/pkg/gpu/nvidia/gpumanager.go
@@ -61,8 +61,10 @@ L:
 				devicePlugin.Stop()
 			}
 
-			devicePlugin = NewNvidiaDevicePlugin(ngm.enableMPS, ngm.healthCheck)
-			if err := devicePlugin.Serve(); err != nil {
+			devicePlugin, err = NewNvidiaDevicePlugin(ngm.enableMPS, ngm.healthCheck)
+			if err != nil {
+				log.Warningf("Failed to get device plugin due to %v", err)
+			} else if err = devicePlugin.Serve(); err != nil {
 				log.Warningf("Failed to start device plugin due to %v", err)
 			} else {
 				restart = false

--- a/pkg/gpu/nvidia/server.go
+++ b/pkg/gpu/nvidia/server.go
@@ -32,7 +32,7 @@ type NvidiaDevicePlugin struct {
 }
 
 // NewNvidiaDevicePlugin returns an initialized NvidiaDevicePlugin
-func NewNvidiaDevicePlugin(mps, healthCheck bool) *NvidiaDevicePlugin {
+func NewNvidiaDevicePlugin(mps, healthCheck bool) (*NvidiaDevicePlugin, error) {
 	devs, devNameMap := getDevices()
 	devList := []string{}
 
@@ -45,7 +45,7 @@ func NewNvidiaDevicePlugin(mps, healthCheck bool) *NvidiaDevicePlugin {
 
 	err := patchGPUCount(len(devList))
 	if err != nil {
-		log.Infof("Failed due to %v", err)
+		return nil, err
 	}
 
 	return &NvidiaDevicePlugin{
@@ -58,7 +58,7 @@ func NewNvidiaDevicePlugin(mps, healthCheck bool) *NvidiaDevicePlugin {
 
 		stop:   make(chan struct{}),
 		health: make(chan *pluginapi.Device),
-	}
+	}, nil
 }
 
 func (m *NvidiaDevicePlugin) GetDeviceNameByIndex(index uint) (name string, found bool) {


### PR DESCRIPTION
fix: device plugin在初始化过程中忽略了一些错误导致后期出现不可用异常